### PR TITLE
Feat: Cancel Reservation

### DIFF
--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/error/ErrorMessage.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/error/ErrorMessage.kt
@@ -12,6 +12,7 @@ enum class ErrorMessage(
     //404 Not Found
     EMPLOYEE_NOT_FOUND(ResponseStatus.NOT_FOUND,"Employee Not Found"),
     SEAT_NOT_FOUND(ResponseStatus.NOT_FOUND,"Seat Not Found"),
+    RESERVATION_NOT_FOUND(ResponseStatus.NOT_FOUND,"Reservation Not Found"),
 
     //409 Conflict (서버와 현재 상태 충돌),
     ALREADY_RESERVED_EMPLOYEE(ResponseStatus.CONFLICT,"This user has already completed a reservation"),

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/controller/SeatController.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/controller/SeatController.kt
@@ -40,4 +40,18 @@ class SeatController (
             reservation
         )
     }
+
+    @DeleteMapping("/reservations")
+    fun cancelReservation(@RequestBody reservationDto: ReservationDto) : ApplicationResponseDto<ReservationDto> {
+
+        val cancelReservation = seatService.cancelReservation(reservationDto)
+
+        return ApplicationResponseDto(
+            ResponseStatus.SUCCESS,
+            "좌석 예약이 취소되었습니다.",
+            ResponseStatus.SUCCESS.code,
+            true,
+            cancelReservation
+        )
+    }
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatCustomRepository.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatCustomRepository.kt
@@ -5,4 +5,5 @@ import com.lottehealthcare.officereservationsystem.seat.entity.EmployeeSeat
 interface EmployeeSeatCustomRepository {
     fun findBySeatNumber(seatNumber: Short?): EmployeeSeat?
     fun findByEmployeeNumber(employeeNumber: Short?): EmployeeSeat?
+    fun findByEmployeeSeatNumber(employeeNumber: Short?, seatNumber: Short?): EmployeeSeat?
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatCustomRepositoryImpl.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatCustomRepositoryImpl.kt
@@ -25,4 +25,13 @@ class EmployeeSeatCustomRepositoryImpl (
                 qEmployeeSeat.isValid.isTrue)
             .fetchOne()
     }
+
+    override fun findByEmployeeSeatNumber(employeeNumber: Short?, seatNumber: Short?): EmployeeSeat? {
+        return  jpaQueryFactory
+            .selectFrom(qEmployeeSeat)
+            .where(qEmployeeSeat.seat.seatNumber.eq(seatNumber),
+                qEmployeeSeat.employee.employeeNumber.eq(employeeNumber),
+                qEmployeeSeat.isValid.isTrue)
+            .fetchOne()
+    }
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatService.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatService.kt
@@ -8,4 +8,5 @@ interface SeatService {
 
     fun registerNewSeat(seat: RegisterSeatDto): SeatInformationDto
     fun makeReservation(reservationInfo: ReservationDto): ReservationDto
+    fun cancelReservation(reservationInfo: ReservationDto): ReservationDto
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImpl.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImpl.kt
@@ -73,4 +73,24 @@ class SeatServiceImpl (
         return ReservationDto.fromEntity(
             employeeSeatRepository.save(newReservation))
     }
+
+    override fun cancelReservation(reservationInfo: ReservationDto): ReservationDto {
+
+        //1) 예약자와 좌석의 데이터 존재 확인
+        val employee = employeeRepository.findByEmployeeNumber(reservationInfo.employeeNumber)
+            ?: throw BusinessException(ErrorMessage.EMPLOYEE_NOT_FOUND)
+
+        val seat = seatRepository.findBySeatNumber(reservationInfo.seatNumber)
+            ?: throw BusinessException(ErrorMessage.SEAT_NOT_FOUND)
+
+        //2) 예약자-좌석 : 실제로 예약되어있는지, isValid = true
+        val cancelData = employeeSeatRepository.findByEmployeeSeatNumber(reservationInfo.employeeNumber, reservationInfo.seatNumber)
+            ?: throw BusinessException(ErrorMessage.RESERVATION_NOT_FOUND)
+
+        //여기까지 왔으면 취소해도 되는 예약!
+        cancelData.isValid = false
+        employee.currentWorkType = WorkType.재택 //(고민) 요구사항에 따라 Default를 재택으로 설정하고, 미출근을 없애는게 맞는지
+
+        return reservationInfo //단순 취소자와 취소된 좌석번호에 대한 정보만 반환해도 되므로 그대로 반환
+    }
 }


### PR DESCRIPTION

# ✅ 예약 취소 API의 기본 동작 구현

`직원번호` & `좌석번호` & `isValid=true`인지 조회합니다.



### 1️⃣ 예약 취소 성공

```json
{
    "status": "SUCCESS",
    "message": "좌석 예약이 취소되었습니다.",
    "code": 200,
    "isSuccess": true,
    "data": {
        "employeeNumber": 1,
        "seatNumber": 1
    }
}
```

---

### 2️⃣ 예약 정보가 없음
```json
{
    "status": "NOT_FOUND",
    "message": "Reservation Not Found",
    "code": 404,
    "isSuccess": false,
    "data": null
}
```

---

### 3️⃣ 이미 취소한 좌석  - 동일 직원 예약 시도
- 요구사항 :  동일한 좌석은 하루에 1번만 예약이 가능합니다.  

```json
{
    "status": "BAD_REQUEST",
    "message": "Previously reserved seats cannot be re-reserved",
    "code": 400,
    "isSuccess": false,
    "data": null
}
```

---



### 4️⃣ 이미 취소한 좌석  - 다른 직원 예약 시도
- 요구사항 : 예약을 취소하면 다른 직원이 해당 좌석을 예약할 수 있습니다.

```json
{
    "status": "SUCCESS",
    "message": "좌석 예약에 성공했습니다.",
    "code": 200,
    "isSuccess": true,
    "data": {
        "employeeNumber": 2,
        "seatNumber": 1
    }
}
```

# ✅ Demo Image
<img width="339" alt="스크린샷 2023-11-18 오전 10 39 35" src="https://github.com/sdoaolo/office-reservation-api/assets/48430781/5b11e8f7-0701-4036-b28d-489aad91a287">

