### PR TITLE
Feat: check remaining seats

### DIFF
--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/common/ResponseStatus.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/common/ResponseStatus.kt
@@ -7,5 +7,6 @@ enum class ResponseStatus(
     BAD_REQUEST(400),
     NOT_FOUND(404),
     CONFLICT(409),
+    UNPROCESSABLE_ENTITY(422),
     INTERNAL_SERVER_ERROR(500)
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/error/ErrorMessage.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/error/ErrorMessage.kt
@@ -16,5 +16,8 @@ enum class ErrorMessage(
 
     //409 Conflict (서버와 현재 상태 충돌),
     ALREADY_RESERVED_EMPLOYEE(ResponseStatus.CONFLICT,"This user has already completed a reservation"),
-    ALREADY_RESERVED_SEAT(ResponseStatus.CONFLICT,"This seat is already reserved. Please choose a different seat.")
+    ALREADY_RESERVED_SEAT(ResponseStatus.CONFLICT,"This seat is already reserved. Please choose a different seat"),
+
+    //422 Unprocessable Entity : 요청은 명확하나, 처리할 수 없음
+    NO_REMAINING_SEATS(ResponseStatus.UNPROCESSABLE_ENTITY, "There are no remaining seats. ")
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatRepository.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatRepository.kt
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface EmployeeSeatRepository: JpaRepository<EmployeeSeat, Long>, EmployeeSeatCustomRepository {
     fun findByEmployeeAndSeat(employee: Employee, seat: Seat): EmployeeSeat?
+    fun countByIsValidTrue(): Long
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImpl.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImpl.kt
@@ -35,7 +35,8 @@ class SeatServiceImpl (
 
     override fun makeReservation(reservationInfo: ReservationDto): ReservationDto {
 
-        //체크0) 좌석이 남았는지 (구현 필요)
+        //체크0) 사용가능한 좌석이 남아있는지 확인
+        checkRemainingSeats()
 
         //체크1,2) 예약자, 좌석이 존재하는 번호인지 확인한다.
         val employee = verifiedEmployee(reservationInfo.employeeNumber)
@@ -96,5 +97,15 @@ class SeatServiceImpl (
         val seat = seatRepository.findBySeatNumber(seatNumber)
             ?: throw BusinessException(ErrorMessage.SEAT_NOT_FOUND)
         return seat
+    }
+
+    private fun checkRemainingSeats() {
+        //좌석 자체가 없는경우
+        val activeSeats = employeeSeatRepository.countByIsValidTrue()
+        val totalSeats = seatRepository.count()
+
+        if (totalSeats - activeSeats < 1) {
+            throw BusinessException(ErrorMessage.NO_REMAINING_SEATS)
+        }
     }
 }


### PR DESCRIPTION
# ✅ 남은 좌석의 개수 파악

### 🤔 
남은 좌석의 개수 파악이 <좌석 예약 API> 의 책임이 맞는지 고민중에 있습니다. 
클라이언트의 입장을 고려했을 때 더 나은 설계는 <남은 좌석 조회 API>를 생성하면 더 나을것으로 판단되지만, 

작성해주신 요구사항 중
 **`좌석이 남는 경우는 가능합니다.`** 가 존재하기 떄문에 
좌석 예약 API에 추가했습니다.

--- 

### 1️⃣ 구현 내용
✔️ 사용가능한 좌석이 남아있는지 확인
✔️ 없을 경우 응답 메세지 설정
```json
{
    "status": "UNPROCESSABLE_ENTITY",
    "message": "There are no remaining seats. ",
    "code": 422,
    "isSuccess": false,
    "data": null
}
```
 

### 2️⃣ 특이사항 
현재 버전은 직원의 Default WorkType = 재택으로 구현이 되어있습니다.
따라서  `**좌석이 모두 예약되는 경우, 예약하지 못한 직원은 자동으로 재택근무 형태가 지정됩니다.**`
이 요구사항에 대한 구현을 할 필요가 없다고 판단했습니다.

---

## Demo Image

![image](https://github.com/sdoaolo/office-reservation-api/assets/48430781/0da9c050-5976-48fb-84db-c5d11ddcc419)

1. 직원(26개), 좌석 (10개) 생성
2. 10개의 좌석을 모두 예약
3. 이후 아직 예약하지 못한 직원이 새로운 예약 요청시에 받는 응답입니다.
