### PR TITLE
feat: check dto valid

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,9 @@ dependencies {
 	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 
+	//validation
+	implementation("org.springframework.boot:spring-boot-starter-validation")
+
 	//querydsl
 	implementation("com.querydsl:querydsl-jpa:5.0.0")
 	kapt("com.querydsl:querydsl-apt:5.0.0:jpa")

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/aop/ExceptionAdvice.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/aop/ExceptionAdvice.kt
@@ -3,6 +3,7 @@ package com.lottehealthcare.officereservationsystem.aop
 import com.lottehealthcare.officereservationsystem.common.ApplicationResponseDto
 import com.lottehealthcare.officereservationsystem.common.ResponseStatus
 import com.lottehealthcare.officereservationsystem.error.exception.BusinessException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.NoHandlerFoundException
@@ -11,6 +12,29 @@ import javax.servlet.http.HttpServletRequest
 @RestControllerAdvice
 class ExceptionAdvice {
 
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationExceptions(
+        e: MethodArgumentNotValidException,
+        request: HttpServletRequest
+    ): ApplicationResponseDto<Any?> {
+
+        val errors =
+            e.bindingResult.fieldErrors.map { fieldError -> "${fieldError.field}: ${fieldError.defaultMessage}" }
+
+        val errorMessage: String = if (errors.isNotEmpty()) {
+            errors.joinToString(", ")
+        } else {
+            "잘못된 요청입니다"
+        }
+
+        return ApplicationResponseDto(
+            status = ResponseStatus.BAD_REQUEST,
+            message = errorMessage,
+            code = ResponseStatus.BAD_REQUEST.code,
+            isSuccess = false,
+            data = null
+        )
+    }
     @ExceptionHandler(NoHandlerFoundException::class)
     fun handleUrlNotFoundException(
         e: NoHandlerFoundException,

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/employee/controller/EmployeeController.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/employee/controller/EmployeeController.kt
@@ -7,6 +7,7 @@ import com.lottehealthcare.officereservationsystem.employee.dto.response.Current
 import com.lottehealthcare.officereservationsystem.employee.dto.response.SimpleImformationEmployeeDto
 import com.lottehealthcare.officereservationsystem.employee.service.EmployeeService
 import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/api/v1/employees")
@@ -14,7 +15,7 @@ class EmployeeController(
     private val employeeService: EmployeeService
 ){
     @PostMapping
-    fun registerNewEmployee(@RequestBody registerEmployee: RegisterNewEmployeeDto): ApplicationResponseDto<SimpleImformationEmployeeDto> {
+    fun registerNewEmployee(@RequestBody @Valid registerEmployee: RegisterNewEmployeeDto): ApplicationResponseDto<SimpleImformationEmployeeDto> {
 
         return ApplicationResponseDto(
             ResponseStatus.SUCCESS,

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/employee/dto/request/RegisterNewEmployeeDto.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/employee/dto/request/RegisterNewEmployeeDto.kt
@@ -2,8 +2,13 @@ package com.lottehealthcare.officereservationsystem.employee.dto.request
 
 import com.lottehealthcare.officereservationsystem.common.mapping.ToEntityConvertible
 import com.lottehealthcare.officereservationsystem.employee.entity.Employee
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 data class RegisterNewEmployeeDto(
+
+    @field:NotBlank
+    @field:Size(max = 20, message = "The maximum number of characters is 20")
     var name: String,
 ): ToEntityConvertible<Employee> {
     override fun toEntity(): Employee {

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/employee/dto/response/CurrentWorkStatusDto.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/employee/dto/response/CurrentWorkStatusDto.kt
@@ -3,6 +3,7 @@ package com.lottehealthcare.officereservationsystem.employee.dto.response
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.lottehealthcare.officereservationsystem.employee.WorkType
 import com.lottehealthcare.officereservationsystem.employee.entity.Employee
+
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class CurrentWorkStatusDto(
     var name: String,

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/controller/SeatController.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/controller/SeatController.kt
@@ -7,6 +7,7 @@ import com.lottehealthcare.officereservationsystem.seat.dto.request.ReservationD
 import com.lottehealthcare.officereservationsystem.seat.dto.request.RegisterSeatDto
 import com.lottehealthcare.officereservationsystem.seat.service.SeatService
 import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
 
 @RestController
 @RequestMapping("/api/v1/seats")
@@ -14,7 +15,7 @@ class SeatController (
     private val seatService: SeatService
 ) {
     @PostMapping
-    fun registerNewSeat(@RequestBody registerSeatDto: RegisterSeatDto): ApplicationResponseDto<SeatInformationDto> {
+    fun registerNewSeat(@RequestBody @Valid registerSeatDto: RegisterSeatDto): ApplicationResponseDto<SeatInformationDto> {
 
         return ApplicationResponseDto(
             ResponseStatus.SUCCESS,
@@ -25,7 +26,7 @@ class SeatController (
         )
     }
     @PostMapping("/reservations")
-    fun makeReservation(@RequestBody reservationDto: ReservationDto): ApplicationResponseDto<ReservationDto> {
+    fun makeReservation(@RequestBody @Valid reservationDto: ReservationDto): ApplicationResponseDto<ReservationDto> {
 
         return ApplicationResponseDto(
             ResponseStatus.SUCCESS,
@@ -37,7 +38,7 @@ class SeatController (
     }
 
     @DeleteMapping("/reservations")
-    fun cancelReservation(@RequestBody reservationDto: ReservationDto) : ApplicationResponseDto<ReservationDto> {
+    fun cancelReservation(@RequestBody @Valid reservationDto: ReservationDto) : ApplicationResponseDto<ReservationDto> {
 
         return ApplicationResponseDto(
             ResponseStatus.SUCCESS,

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/dto/request/RegisterSeatDto.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/dto/request/RegisterSeatDto.kt
@@ -2,8 +2,13 @@ package com.lottehealthcare.officereservationsystem.seat.dto.request
 
 import com.lottehealthcare.officereservationsystem.common.mapping.ToEntityConvertible
 import com.lottehealthcare.officereservationsystem.seat.entity.Seat
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
 
 data class RegisterSeatDto (
+
+    @field:NotBlank(message = "Location must not be blank")
+    @field:Size(max = 50, message = "The maximum number of characters is 50")
     var seatLocation: String
 ): ToEntityConvertible<Seat> {
     override fun toEntity(): Seat {

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/dto/request/ReservationDto.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/dto/request/ReservationDto.kt
@@ -1,9 +1,18 @@
 package com.lottehealthcare.officereservationsystem.seat.dto.request
 
 import com.lottehealthcare.officereservationsystem.seat.entity.EmployeeSeat
+import org.jetbrains.annotations.NotNull
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 
 data class ReservationDto(
+
+    @field:NotNull
+    @field:Min(1) @field:Max(150)
     var employeeNumber: Short,
+
+    @field:NotNull
+    @field:Min(1) @field:Max(100)
     var seatNumber : Short
 ){
     companion object {


### PR DESCRIPTION
# 구현내용
- dto, controller에 유효성 검증 추가
- 유효성 검증 실패시 에러 메세지 커스텀

---

# ✅ 직원 추가 API


### 1. 이름 NULL, 공백으로 넣었을 때
```json
{
    "status": "BAD_REQUEST",
    "message": "name: 공백일 수 없습니다",
    "code": 400,
    "isSuccess": false
}
```

### 2. 이름 20자 초과 요청시  
```json
{
    "status": "BAD_REQUEST",
    "message": "name: The maximum number of characters is 20",
    "code": 400,
    "isSuccess": false
}
```

* 좌석 추가 API도 동일한 결과를 제공합니다.


----



# ✅ 좌석 예약 / 취소 API

## 1. 유효 범위를 벗어났을 때
- employeeNumber (1~150) 
- seatNumber(1~100) 

### ⏺ **_request_**
```json
{
    "employeeNumber": 333,
	"seatNumber": 444
}
```
### ⏺ **_response_**
```json
{
    "status": "BAD_REQUEST",
    "message": "employeeNumber: 150 이하여야 합니다, seatNumber: 100 이하여야 합니다",
    "code": 400,
    "isSuccess": false
}
```


## 2. 데이터 자체를 잘못 넣었을 때 

### ⏺ **_request_**
```json
{
    "employeeNumber": "안녕하세요",
	"seatNumber": 1
}
```
### ⏺ **_response_**
```json
{
    "timestamp": "2023-11-19T05:59:42.762+00:00",
    "status": 400,
    "error": "Bad Request",
    "path": "/api/v1/seats/reservations"
}
```
