### PR TITLE
Feat: make employee work status <재택> at 12am

### DIFF
--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/OfficeReservationSystemApplication.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/OfficeReservationSystemApplication.kt
@@ -3,9 +3,11 @@ package com.lottehealthcare.officereservationsystem
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 class OfficeReservationSystemApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/scheduling/WorkStatusResetScheduler.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/scheduling/WorkStatusResetScheduler.kt
@@ -1,0 +1,20 @@
+package com.lottehealthcare.officereservationsystem.scheduling
+
+import com.lottehealthcare.officereservationsystem.employee.WorkType
+import com.lottehealthcare.officereservationsystem.employee.repository.EmployeeRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class WorkStatusResetScheduler(
+    private val employeeRepository: EmployeeRepository
+) {
+    @Scheduled(cron = "0 0 0 * * ?")
+    fun resetEmployeeWorkStatus() {
+        val allEmployees = employeeRepository.findAll()
+        for (employee in allEmployees) {
+            employee.currentWorkType = WorkType.재택
+        }
+        employeeRepository.saveAll(allEmployees)
+    }
+}


### PR DESCRIPTION
# ✅ 구현 목적 

## 🤔  **`Problem`** 
: 어제 예약한 내용을 기반으로 상태값이 업데이트 되어있는 문제 발견 

### **`Example`**
**📆 11월 19일** 
- 1번 직원이 1번좌석을 예약하면 
- 1번 직원의 work-status = 오피스근무로 변경됨

**📆 11월 20일** 
- 다음날 전체직원 상태 조회 > 1번직원의 work-status는 오피스근무인 이후로 변경된지 않음

<br>

-> 예약정보는 삭제되지 않기 때문에 <전체 직원의 상태 조회>시 위에 정의한 버그 발생, 
-> 매일 work-status값의 초기화 필요

<br><br>

#  ✅ 구현 내용
- 스케쥴링을 이용하여 매일 오전 12시에 currentWorkType을 재택으로 초기화하도록 구현했습니다.