### PR TITLE
Bug: cancelData 확인 시 date filtering 없어 발생하는 문제 해결

### DIFF
--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatRepository.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/repository/EmployeeSeatRepository.kt
@@ -4,8 +4,10 @@ import com.lottehealthcare.officereservationsystem.employee.entity.Employee
 import com.lottehealthcare.officereservationsystem.seat.entity.EmployeeSeat
 import com.lottehealthcare.officereservationsystem.seat.entity.Seat
 import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
 
 interface EmployeeSeatRepository: JpaRepository<EmployeeSeat, Long>, EmployeeSeatCustomRepository {
-    fun findByEmployeeAndSeat(employee: Employee, seat: Seat): EmployeeSeat?
+
+    fun findByEmployeeAndSeatAndReserveDate(employee: Employee, seat: Seat, reserveDate: LocalDate): EmployeeSeat?
     fun countByIsValidTrue(): Long
 }

--- a/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImpl.kt
+++ b/src/main/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImpl.kt
@@ -14,6 +14,7 @@ import com.lottehealthcare.officereservationsystem.seat.entity.Seat
 import com.lottehealthcare.officereservationsystem.seat.repository.EmployeeSeatRepository
 import com.lottehealthcare.officereservationsystem.seat.repository.SeatRepository
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import javax.transaction.Transactional
 
 @Service
@@ -55,7 +56,7 @@ class SeatServiceImpl (
 
         //체크4) 이미 employee-seat에 데이터가 있는가? (예약자가 예약했던 좌석인가?) --isValid는 true/false 상관없다.
         //4-1 존재하는 경우 - 예약했다 취소한 좌석은 다시 예약할 수 없습니다. (응답 반환)
-        val cancelData = employeeSeatRepository.findByEmployeeAndSeat(employee, seat)
+        val cancelData = employeeSeatRepository.findByEmployeeAndSeatAndReserveDate(employee, seat, LocalDate.now())
             ?.let{ throw BusinessException(ErrorMessage.CANNOT_RE_RESERVE) }
 
         val newReservation = EmployeeSeat(

--- a/src/test/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImplExceptionTest.kt
+++ b/src/test/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImplExceptionTest.kt
@@ -167,7 +167,7 @@ class SeatServiceImplExceptionTest {
         every { employeeSeatRepository.findByEmployeeNumberToday(any()) } returns null
         every { employeeSeatRepository.findBySeatNumberToday(any()) } returns null
 
-        every { employeeSeatRepository.findByEmployeeAndSeat(any(), any()) } returns cancelData
+        every { employeeSeatRepository.findByEmployeeAndSeatAndReserveDate(any(), any(), any()) } returns cancelData
 
         // When & Then
         assertThrows<BusinessException> {

--- a/src/test/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImplTest.kt
+++ b/src/test/kotlin/com/lottehealthcare/officereservationsystem/seat/service/SeatServiceImplTest.kt
@@ -89,7 +89,7 @@ class SeatServiceImplTest {
         //check 3-1, 3-2, 4
         every { employeeSeatRepository.findByEmployeeNumberToday(any()) } returns null
         every { employeeSeatRepository.findBySeatNumberToday(any()) } returns null
-        every { employeeSeatRepository.findByEmployeeAndSeat(any(), any()) } returns null
+        every { employeeSeatRepository.findByEmployeeAndSeatAndReserveDate(any(), any(), any()) } returns null
 
         //save reservation
         every { employeeSeatRepository.save(any()) } returns newReservation


### PR DESCRIPTION
# ✅  Today filtering 추가

## 🤔 Problem
좌석 예약 상황에서 이미 취소한적 있는 데이터 (cancelData)를 확인하는 작업에서

`오늘` 예약하지 않았는데, 
이전날짜의 예약값이 존재해 예약이 안되는 케이스를 확인했습니다.

## 😉 Solve
오늘 날짜에 대한 필터링을 추가해 해결했습니다.